### PR TITLE
Create separate optimizer for buckets

### DIFF
--- a/src/chatbot.py
+++ b/src/chatbot.py
@@ -196,7 +196,6 @@ def _construct_response(output_logits, inv_dec_vocab):
     return " ".join([tf.compat.as_str(inv_dec_vocab[output]) for output in outputs])
 
 def _pick_topN_response(output_logits, inv_dec_vocab, topN = 4):
-    outputs = [int(np.argmax(logit, axis=1)) for logit in output_logits]
     outputs = [np.argsort(logit, axis=1)[0][-topN:] for logit in output_logits]
     # If there is an EOS symbol in outputs, cut them at that point.
     # for output in outputs:
@@ -205,8 +204,7 @@ def _pick_topN_response(output_logits, inv_dec_vocab, topN = 4):
     # Print out sentence corresponding to outputs.
     for i in range(topN):
         response = " ".join([tf.compat.as_str(inv_dec_vocab[output[i]]) for output in outputs])
-        print(response, '\n')
-    # return [[" ".join([tf.compat.as_str(inv_dec_vocab[int(output[i])]) for output in outputs])] for i in range(topN)]
+        print(str(i) + '. ' + response, '\n')
     return ""
 
 def chat():

--- a/src/model.py
+++ b/src/model.py
@@ -111,12 +111,14 @@ class ChatBotModel:
                 0, dtype=tf.int32, trainable=False, name='global_step')
 
             if not self.fw_only:
-                self.optimizer = tf.train.GradientDescentOptimizer(config.LR)
                 trainables = tf.trainable_variables()
                 self.gradient_norms = []
                 self.train_ops = []
                 start = time.time()
+                LR = config.LR
                 for bucket in range(len(config.BUCKETS)):
+                    self.optimizer = tf.train.GradientDescentOptimizer(LR)
+                    LR += 0.01
                     clipped_grads, norm = tf.clip_by_global_norm(
                       tf.gradients(
                         self.losses[bucket], 


### PR DESCRIPTION
See the **Tips** section of the [pdf](https://web.stanford.edu/class/cs20si/2017/assignments/a3.pdf).

> 2. Adjust the learning rate
> You should pay attention to the reported loss and adjust the learning rate accordingly. Please read the CS231N note on how to read your learning rate.
> Keep in mind that each bucket has its own optimizer, so you can have different learning rates for different buckets. ***For example, buckets with a larger size might need a slightly larger learning rate.***
> You should feel free to experiment with other optimizers other than SGD.

We have `BUCKETS = [(8, 10), (12, 14), (16, 19)]`, so they should have different LR.

In training, we can clearly see that the loss of the last two buckets is higher than the first bucket, thus, they need higher LR.

```
Iter 52900: loss 4.198194634914398, time 0.11628055572509766
Iter 53000: loss 4.188888585567474, time 0.12644100189208984
Test bucket 0: loss 4.001251697540283, time 0.07473897933959961
Test bucket 1: loss 4.44882869720459, time 0.09836626052856445
Test bucket 2: loss 4.317837715148926, time 0.13316082954406738
Iter 53100: loss 4.190840768814087, time 0.17204761505126953
Iter 53200: loss 4.125140860080719, time 0.12006711959838867
```